### PR TITLE
change bookworm to trixie

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,17 +12,17 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - ghcr.io/toshy/php:8.2-fpm-bookworm
-          - ghcr.io/toshy/php:8.3-fpm-bookworm
-          - ghcr.io/toshy/php:8.4-fpm-bookworm
+          - ghcr.io/toshy/php:8.2-fpm-trixie
+          - ghcr.io/toshy/php:8.3-fpm-trixie
+          - ghcr.io/toshy/php:8.4-fpm-trixie
           - ghcr.io/toshy/php:8.5-fpm-trixie
-          - ghcr.io/toshy/php:8.2-fpm-bookworm-ffmpeg
-          - ghcr.io/toshy/php:8.3-fpm-bookworm-ffmpeg
-          - ghcr.io/toshy/php:8.4-fpm-bookworm-ffmpeg
+          - ghcr.io/toshy/php:8.2-fpm-trixie-ffmpeg
+          - ghcr.io/toshy/php:8.3-fpm-trixie-ffmpeg
+          - ghcr.io/toshy/php:8.4-fpm-trixie-ffmpeg
           - ghcr.io/toshy/php:8.5-fpm-trixie-ffmpeg
-          - ghcr.io/toshy/php:8.2-fpm-bookworm-otel
-          - ghcr.io/toshy/php:8.3-fpm-bookworm-otel
-          - ghcr.io/toshy/php:8.4-fpm-bookworm-otel
+          - ghcr.io/toshy/php:8.2-fpm-trixie-otel
+          - ghcr.io/toshy/php:8.3-fpm-trixie-otel
+          - ghcr.io/toshy/php:8.4-fpm-trixie-otel
           - ghcr.io/toshy/php:8.5-fpm-trixie-otel
     steps:
       - name: Scan for vulnerabilities

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,5 @@ EOT
 RUN <<EOT sh
   set -ex
   install-php-extensions opentelemetry \
-    grpc-1.78.0RC2 \
     protobuf
 EOT

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -25,7 +25,7 @@ variable "DEFAULT_FLAVOR" {
 }
 
 variable "DEFAULT_OS" {
-    default = "bookworm"
+    default = "trixie"
 }
 
 variable "DEFAULT_TARGET" {
@@ -34,19 +34,19 @@ variable "DEFAULT_TARGET" {
 
 variable "PHP_OS_MAP" {
     default = {
-        "8.2" = "bookworm"
-        "8.3" = "bookworm"
-        "8.4" = "bookworm"
+        "8.2" = "trixie"
+        "8.3" = "trixie"
+        "8.4" = "trixie"
         "8.5" = "trixie"
     }
 }
 
 variable "FLAVOR_OS_MAP" {
     default = {
-        "cli" = "bookworm,trixie,alpine"
-        "apache" = "bookworm,trixie" # apache flavor has no alpine os image
-        "fpm" = "bookworm,trixie,alpine"
-        "zts" = "bookworm,trixie,alpine"
+        "cli" = "trixie,alpine"
+        "apache" = "trixie" # apache flavor has no alpine os image
+        "fpm" = "trixie,alpine"
+        "zts" = "trixie,alpine"
     }
 }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,8 +36,8 @@ ghcr.io/toshy/php:<version>-<flavor>-<os>(-<target>)
 ```
 
 - Contains the following PHP versions: `8.2`, `8.3`, `8.4`, `8.5`.
-- Contains the following flavors: `cli`, `fpm`, `apache`, `zts`
-- Contains the following OS: `bookworm`, `trixie`.
+- Contains the following flavors: `cli`, `fpm`, `apache`, `zts`.
+- Contains the following OS: `trixie` (deprecated: `bookworm`).
 - Contains the following [targets](images.md#targets): `base`, `ffmpeg`, `otel`.
 
 !!!question


### PR DESCRIPTION
## Description

Changes `bookworm` to `trixie` as base OS for all php images (8.2+ all support trixie now).

## Checklist

- [x] My code adheres to the style guidelines of this project
- [x] I have conducted a self-review of my code
- [x] I have added comments to my code, especially in areas that may be difficult to understand
